### PR TITLE
Lock UI elements for which the user/safe doesn't have access

### DIFF
--- a/src/components/Modals/PermissionsModal/Modal.tsx
+++ b/src/components/Modals/PermissionsModal/Modal.tsx
@@ -51,6 +51,7 @@ type Props = {
   onSubmitForm: () => any;
   onPermissionToggle: (itemId: number | string, checked: boolean) => any;
   onClose: () => any;
+  newAccount?: boolean;
 };
 
 const PermissionsToggleList = ({
@@ -99,13 +100,18 @@ const ManageList = ({
   permissionsList,
   defaultIconUrl,
   isSubmitFormDisabled = false,
+  newAccount,
   onSubmitForm,
   onPermissionToggle,
   onClose,
 }: Props) => {
   const getBody = () => (
     <>
-      <BodyHeader>placeholder</BodyHeader>
+      {newAccount && (
+        <BodyHeader>
+          <Text size="md"> Adding New Account</Text>
+        </BodyHeader>
+      )}
       <div>
         <PermissionsToggleList
           permissions={permissionsList}

--- a/src/components/Modals/PermissionsModal/Modal.tsx
+++ b/src/components/Modals/PermissionsModal/Modal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { GenericModal, Text, Switch, ModalFooterConfirmation } from "@gnosis.pm/safe-react-components";
+import { Permission } from "./types";
 
 const BodyHeader = styled.div`
   display: flex;
@@ -45,59 +46,72 @@ const TextDesc = styled(Text)`
 type Props = {
   title?: string;
   defaultIconUrl: string;
-  itemList: Array<{
-    id: number | string;
-    iconUrl: string;
-    name: string;
-    description?: string;
-    checked: boolean;
-  }>;
+  permissionsList: Permission[];
   isSubmitFormDisabled?: boolean;
   onSubmitForm: () => any;
-  onItemToggle: (itemId: number | string, checked: boolean) => any;
+  onPermissionToggle: (itemId: number | string, checked: boolean) => any;
   onClose: () => any;
 };
 
-const ManageList = ({
-  title = "Set Permissions",
-  itemList,
+const PermissionsToggleList = ({
+  permissions,
+  onPermissionToggle,
   defaultIconUrl,
-  isSubmitFormDisabled = false,
-  onSubmitForm,
-  onItemToggle,
-  onClose,
-}: Props) => {
+}: {
+  permissions: Permission[];
+  onPermissionToggle: (itemId: number | string, checked: boolean) => any;
+  defaultIconUrl: string;
+}) => {
   const setDefaultImage = (e: any) => {
     e.target.onerror = null;
     e.target.src = defaultIconUrl;
   };
+  return (
+    <>
+      {permissions.map(i => {
+        const onChange = (checked: boolean) => onPermissionToggle(i.id, checked);
 
+        return (
+          <StyledItem key={i.id}>
+            <StyledImageName>
+              <StyledImage alt={i.name} onError={setDefaultImage} src={i.iconUrl} />
+              <div>
+                <div>
+                  <Text size="lg" strong>
+                    {i.name}
+                  </Text>
+                </div>
+                <div>
+                  <TextDesc size="md">{i.description && i.description}</TextDesc>
+                </div>
+              </div>
+            </StyledImageName>
+            <Switch checked={i.checked} onChange={onChange} />
+          </StyledItem>
+        );
+      })}
+    </>
+  );
+};
+
+const ManageList = ({
+  title = "Set Permissions",
+  permissionsList,
+  defaultIconUrl,
+  isSubmitFormDisabled = false,
+  onSubmitForm,
+  onPermissionToggle,
+  onClose,
+}: Props) => {
   const getBody = () => (
     <>
       <BodyHeader>placeholder</BodyHeader>
       <div>
-        {itemList.map(i => {
-          const onChange = (checked: boolean) => onItemToggle(i.id, checked);
-
-          return (
-            <StyledItem key={i.id}>
-              <StyledImageName>
-                <StyledImage alt={i.name} onError={setDefaultImage} src={i.iconUrl} />
-                <div>
-                  <div>
-                    <Text size="lg" strong>
-                      {i.name}
-                    </Text>
-                  </div>
-                  <div>
-                    <TextDesc size="md">{i.description && i.description}</TextDesc>
-                  </div>
-                </div>
-              </StyledImageName>
-              <Switch checked={i.checked} onChange={onChange} />
-            </StyledItem>
-          );
-        })}
+        <PermissionsToggleList
+          permissions={permissionsList}
+          onPermissionToggle={onPermissionToggle}
+          defaultIconUrl={defaultIconUrl}
+        />
       </div>
     </>
   );

--- a/src/components/Modals/PermissionsModal/index.tsx
+++ b/src/components/Modals/PermissionsModal/index.tsx
@@ -9,14 +9,7 @@ import RootIcon from "../../../assets/permissions/root.svg";
 
 import ManageListModal from "./Modal";
 import { shortenAddress } from "../../../utils";
-
-type Permission = {
-  id: string;
-  iconUrl: any;
-  name: string;
-  description: string;
-  checked: boolean;
-};
+import { Permission } from "./types";
 
 const setInitialPermissions = (permissions: number[]): Permission[] => [
   {
@@ -71,7 +64,7 @@ const PermissionsModal = ({
 }: {
   isOpen: boolean;
   setIsOpen: Function;
-  address: string;
+  address?: string;
   permissions: number[];
 }) => {
   const [items, setItems] = useState(setInitialPermissions(permissions));
@@ -89,12 +82,12 @@ const PermissionsModal = ({
   if (!isOpen) return null;
   return (
     <ManageListModal
-      title={shortenAddress(address)}
+      title={address ? shortenAddress(address) : "New Account"}
       defaultIconUrl=""
-      itemList={items}
+      permissionsList={items}
       onSubmitForm={() => console.log("submitted")}
       onClose={() => setIsOpen(false)}
-      onItemToggle={onItemToggle}
+      onPermissionToggle={onItemToggle}
     />
   );
 };

--- a/src/components/Modals/PermissionsModal/index.tsx
+++ b/src/components/Modals/PermissionsModal/index.tsx
@@ -88,6 +88,7 @@ const PermissionsModal = ({
       onSubmitForm={() => console.log("submitted")}
       onClose={() => setIsOpen(false)}
       onPermissionToggle={onItemToggle}
+      newAccount={!address}
     />
   );
 };

--- a/src/components/Modals/PermissionsModal/types.ts
+++ b/src/components/Modals/PermissionsModal/types.ts
@@ -1,0 +1,7 @@
+export type Permission = {
+  id: string;
+  iconUrl: any;
+  name: string;
+  description: string;
+  checked: boolean;
+};

--- a/src/components/Modals/SetRewardsModal/index.tsx
+++ b/src/components/Modals/SetRewardsModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, ChangeEvent } from "react";
 import { Button, GenericModal, TextField, ModalFooterConfirmation } from "@gnosis.pm/safe-react-components";
 
-const SetRewardsModal = () => {
+const SetRewardsModal = ({ disabled }: { disabled?: boolean }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [rewardsPercentage, setRewardsPercentage] = useState<string>("");
 
@@ -26,7 +26,7 @@ const SetRewardsModal = () => {
   );
   return (
     <>
-      <Button size="md" color="primary" onClick={() => setIsOpen(!isOpen)}>
+      <Button size="md" color="primary" onClick={() => setIsOpen(!isOpen)} disabled={disabled}>
         Set Rewards %
       </Button>
       {isOpen && (

--- a/src/components/Modals/TokenModal/index.tsx
+++ b/src/components/Modals/TokenModal/index.tsx
@@ -1,24 +1,35 @@
 import React, { ReactElement } from "react";
-import { ModalFooterConfirmation, GenericModal } from "@gnosis.pm/safe-react-components";
+import { Text, ModalFooterConfirmation, GenericModal } from "@gnosis.pm/safe-react-components";
 import { Token } from "../../../typings";
 
 const TokenModal = ({
   isOpen,
   setIsOpen,
   token,
+  hasRootRole,
+  hasAdministrationRole,
   hasFundingRole,
 }: {
   isOpen: boolean;
   setIsOpen: Function;
   token: Token;
+  hasRootRole: boolean;
+  hasAdministrationRole: boolean;
   hasFundingRole: boolean;
 }): ReactElement | null => {
   const modalTitle = `${token.symbol}`;
 
   const modalBody = (
-    <>{`This is the ${token.symbol} modal ${
-      hasFundingRole ? "This user can transfer funds" : "This user can't transfer funds"
-    }`}</>
+    <>
+      <Text size="lg">{`This is the ${token.symbol} modal`}</Text>
+      <Text size="lg">{hasRootRole ? "This user can mint colony tokens" : "This user can't mint colony tokens"}</Text>
+      <Text size="lg">
+        {hasAdministrationRole ? "This user can initiate payments" : "This user can't initiate payments"}
+      </Text>
+      <Text size="lg">
+        {hasFundingRole ? "This user can transfer funds between pots" : "This user can't transfer funds between pots"}
+      </Text>
+    </>
   );
 
   const modalFooter = (

--- a/src/components/PayoutList/Sidebar.tsx
+++ b/src/components/PayoutList/Sidebar.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { ColonyRole } from "@colony/colony-js";
+import { Button, Text } from "@gnosis.pm/safe-react-components";
+import { useHasDomainPermission } from "../../contexts/ColonyContext";
+import { useSafeInfo } from "../../contexts/SafeContext";
+import SetRewardsModal from "../Modals/SetRewardsModal";
+
+const PayoutSidebar = () => {
+  const safeInfo = useSafeInfo();
+  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
+
+  return (
+    <>
+      <Text size="md">20% of all incoming revenue is contributed to the rewards pot</Text>
+      <SetRewardsModal disabled={!hasRootPermission} />
+      <Button size="md" color="primary" onClick={() => console.log("Opening Lock/Unlock Tokens")}>
+        Lock/Unlock Tokens
+      </Button>
+    </>
+  );
+};
+
+export default PayoutSidebar;

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -1,13 +1,8 @@
 import React, { useMemo, useState } from "react";
-import { Table, TableRow, TableCell } from "@material-ui/core";
-import styled from "styled-components";
+import { TableRow, TableCell } from "@material-ui/core";
+import Table from "../common/StyledTable";
 import PayoutModal from "../Modals/PayoutModal";
 import { Token } from "../../typings";
-
-const StyledTable = styled(Table)`
-  min-width: 480px;
-  box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
-`;
 
 const TokenRow = ({ token }: { token: Token }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -25,7 +20,7 @@ const TokenRow = ({ token }: { token: Token }) => {
 const PayoutList = ({ tokens }: { tokens: Token[] }) => {
   const tokenList = useMemo(() => tokens.map(token => <TokenRow token={token} />), [tokens]);
 
-  return <StyledTable>{tokenList}</StyledTable>;
+  return <Table>{tokenList}</Table>;
 };
 
 export default PayoutList;

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -41,6 +41,7 @@ const AddAddressRow = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   return (
     <>
+      <PermissionsModal isOpen={isOpen} setIsOpen={setIsOpen} address="" permissions={[]} />
       <UnderlinedTableRow onClick={() => setIsOpen(true)}>
         <TableCell>
           <Text size="lg">Add Account</Text>

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 import { ColonyRoles, DomainRoles } from "@colony/colony-js";
 
+import { Text, Icon } from "@gnosis.pm/safe-react-components";
 import PermissionsModal from "../Modals/PermissionsModal";
 import PermissionIcons from "./PermissionIcons";
 import Address from "../common/Address";
@@ -12,6 +13,11 @@ import { useColonyRoles } from "../../contexts/ColonyContext";
 const StyledTable = styled(Table)`
   min-width: 480px;
   box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
+`;
+
+const UnderlinedTableRow = styled(TableRow)`
+  border-bottom-width: 3px;
+  border-bottom-style: solid;
 `;
 
 const AddressRow = ({ address, permissions }: { address: string; permissions: DomainRoles }) => {
@@ -31,6 +37,22 @@ const AddressRow = ({ address, permissions }: { address: string; permissions: Do
   );
 };
 
+const AddAddressRow = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <>
+      <UnderlinedTableRow onClick={() => setIsOpen(true)}>
+        <TableCell>
+          <Text size="lg">Add Account</Text>
+        </TableCell>
+        <TableCell align="right">
+          <Icon type="add" size="md" />
+        </TableCell>
+      </UnderlinedTableRow>
+    </>
+  );
+};
+
 const PermissionsList = () => {
   const roles: ColonyRoles = useColonyRoles();
 
@@ -41,6 +63,7 @@ const PermissionsList = () => {
 
   return (
     <StyledTable>
+      <AddAddressRow />
       {addressList.length > 0 ? (
         addressList
       ) : (

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -24,28 +24,28 @@ const UnderlinedTableRow = styled(TableRow)`
 const AddressRow = ({
   address,
   permissions,
-  hasAdminPermission,
+  hasRootPermission,
 }: {
   address: string;
   permissions: DomainRoles;
-  hasAdminPermission: boolean;
+  hasRootPermission: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [showToolTip, setShowToolTip] = useState<boolean>(false);
 
   const handleClick = useCallback(() => {
-    if (hasAdminPermission) {
+    if (hasRootPermission) {
       setIsOpen(true);
     } else {
       setShowToolTip(true);
       setTimeout(() => setShowToolTip(false), 1500);
     }
-  }, [hasAdminPermission]);
+  }, [hasRootPermission]);
 
   return (
     <>
       <PermissionsModal
-        isOpen={hasAdminPermission && isOpen}
+        isOpen={hasRootPermission && isOpen}
         setIsOpen={setIsOpen}
         address={address}
         permissions={permissions.roles}
@@ -90,20 +90,20 @@ const AddAddressRow = () => {
 
 const PermissionsList = () => {
   const safeInfo = useSafeInfo();
-  const hasAdminPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Administration);
+  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
   const roles: ColonyRoles = useColonyRoles();
 
   const addressList = useMemo(
     () =>
       roles.map(({ address, domains }) => (
-        <AddressRow address={address} permissions={domains[0]} hasAdminPermission={hasAdminPermission} />
+        <AddressRow address={address} permissions={domains[0]} hasRootPermission={hasRootPermission} />
       )),
-    [roles, hasAdminPermission],
+    [roles, hasRootPermission],
   );
 
   return (
     <StyledTable>
-      {hasAdminPermission && <AddAddressRow />}
+      {hasRootPermission && <AddAddressRow />}
       {addressList.length > 0 ? (
         addressList
       ) : (

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -1,13 +1,13 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState } from "react";
 import { Table, TableRow, TableCell } from "@material-ui/core";
 import styled from "styled-components";
 
-import { ColonyRoles, DomainRoles, getColonyRoles } from "@colony/colony-js";
+import { ColonyRoles, DomainRoles } from "@colony/colony-js";
 
 import PermissionsModal from "../Modals/PermissionsModal";
 import PermissionIcons from "./PermissionIcons";
 import Address from "../common/Address";
-import { useColonyClient } from "../../contexts/ColonyContext";
+import { useColonyRoles } from "../../contexts/ColonyContext";
 
 const StyledTable = styled(Table)`
   min-width: 480px;
@@ -32,16 +32,7 @@ const AddressRow = ({ address, permissions }: { address: string; permissions: Do
 };
 
 const PermissionsList = () => {
-  const colonyClient = useColonyClient();
-  const [roles, setRoles] = useState<ColonyRoles>([]);
-
-  useEffect(() => {
-    if (colonyClient) {
-      getColonyRoles(colonyClient).then((newRoles: ColonyRoles) => setRoles(newRoles));
-    } else {
-      setRoles([]);
-    }
-  }, [colonyClient]);
+  const roles: ColonyRoles = useColonyRoles();
 
   const addressList = useMemo(
     () => roles.map(({ address, domains }) => <AddressRow address={address} permissions={domains[0]} />),

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -101,8 +101,6 @@ const PermissionsList = () => {
     [roles, hasAdminPermission],
   );
 
-  console.log(hasAdminPermission);
-
   return (
     <StyledTable>
       {hasAdminPermission && <AddAddressRow />}

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -1,20 +1,17 @@
 import React, { useMemo, useState, useCallback } from "react";
-import { Table, TableRow, TableCell, Tooltip } from "@material-ui/core";
+import { TableRow, TableCell, Tooltip } from "@material-ui/core";
+
 import styled from "styled-components";
 
 import { ColonyRoles, DomainRoles, ColonyRole } from "@colony/colony-js";
 
 import { Text, Icon } from "@gnosis.pm/safe-react-components";
+import Table from "../common/StyledTable";
 import PermissionsModal from "../Modals/PermissionsModal";
 import PermissionIcons from "./PermissionIcons";
 import Address from "../common/Address";
 import { useColonyRoles, useHasDomainPermission } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
-
-const StyledTable = styled(Table)`
-  min-width: 480px;
-  box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
-`;
 
 const UnderlinedTableRow = styled(TableRow)`
   border-bottom-width: 3px;
@@ -102,7 +99,7 @@ const PermissionsList = () => {
   );
 
   return (
-    <StyledTable>
+    <Table>
       {hasRootPermission && <AddAddressRow />}
       {addressList.length > 0 ? (
         addressList
@@ -113,7 +110,7 @@ const PermissionsList = () => {
           </TableCell>
         </TableRow>
       )}
-    </StyledTable>
+    </Table>
   );
 };
 

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -8,11 +8,28 @@ import { useHasDomainPermission } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
 import { Token } from "../../typings";
 
-const TokenRow = ({ token, hasFundingRole }: { token: Token; hasFundingRole: boolean }) => {
+const TokenRow = ({
+  token,
+  hasRootRole,
+  hasAdministrationRole,
+  hasFundingRole,
+}: {
+  token: Token;
+  hasRootRole: boolean;
+  hasAdministrationRole: boolean;
+  hasFundingRole: boolean;
+}) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   return (
     <>
-      <TokenModal isOpen={isOpen} setIsOpen={setIsOpen} token={token} hasFundingRole={hasFundingRole} />
+      <TokenModal
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        token={token}
+        hasRootRole={hasRootRole}
+        hasAdministrationRole={hasAdministrationRole}
+        hasFundingRole={hasFundingRole}
+      />
       <TableRow onClick={() => setIsOpen(true)}>
         <TableCell>{token.symbol}</TableCell>
         <TableCell align="right">0.000</TableCell>
@@ -23,11 +40,21 @@ const TokenRow = ({ token, hasFundingRole }: { token: Token; hasFundingRole: boo
 
 const TokenList = ({ tokens }: { tokens: Token[] }) => {
   const safeInfo = useSafeInfo();
+  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
+  const hasAdministrationPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Administration);
   const hasFundingPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Funding);
 
   const tokenList = useMemo(
-    () => tokens.map(token => <TokenRow token={token} hasFundingRole={hasFundingPermission} />),
-    [tokens, hasFundingPermission],
+    () =>
+      tokens.map(token => (
+        <TokenRow
+          token={token}
+          hasRootRole={hasRootPermission}
+          hasAdministrationRole={hasAdministrationPermission}
+          hasFundingRole={hasFundingPermission}
+        />
+      )),
+    [tokens, hasRootPermission, hasAdministrationPermission, hasFundingPermission],
   );
 
   return <Table>{tokenList}</Table>;

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -1,16 +1,12 @@
 import React, { useMemo, useState } from "react";
-import { Table, TableRow, TableCell } from "@material-ui/core";
-import styled from "styled-components";
+import { TableRow, TableCell } from "@material-ui/core";
 import { ColonyRole } from "@colony/colony-js";
+import Table from "../common/StyledTable";
+
 import TokenModal from "../Modals/TokenModal";
 import { useHasDomainPermission } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
 import { Token } from "../../typings";
-
-const StyledTable = styled(Table)`
-  min-width: 480px;
-  box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
-`;
 
 const TokenRow = ({ token, hasFundingRole }: { token: Token; hasFundingRole: boolean }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -34,7 +30,7 @@ const TokenList = ({ tokens }: { tokens: Token[] }) => {
     [tokens, hasFundingPermission],
   );
 
-  return <StyledTable>{tokenList}</StyledTable>;
+  return <Table>{tokenList}</Table>;
 };
 
 export default TokenList;

--- a/src/components/common/StyledTable.tsx
+++ b/src/components/common/StyledTable.tsx
@@ -1,0 +1,9 @@
+import { Table } from "@material-ui/core";
+import styled from "styled-components";
+
+const StyledTable = styled(Table)`
+  min-width: 480px;
+  box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
+`;
+
+export default StyledTable;

--- a/src/contexts/ColonyContext.tsx
+++ b/src/contexts/ColonyContext.tsx
@@ -1,4 +1,4 @@
-import React, { useState, createContext, ReactElement, useContext, useCallback, useEffect } from "react";
+import React, { useState, createContext, ReactElement, useContext, useCallback, useEffect, useMemo } from "react";
 
 import {
   getColonyNetworkClient,
@@ -14,6 +14,7 @@ import { InfuraProvider } from "ethers/providers";
 import { BigNumber } from "ethers/utils";
 import getColonyTokens from "../utils/colony/getColonyTokens";
 import { Token } from "../typings";
+import userHasDomainRole from "../utils/colony/userHasDomainRole";
 
 interface Props {
   children: ReactElement | ReactElement[];
@@ -22,6 +23,7 @@ interface Props {
 interface State {
   setColony: Function;
   colonyClient?: ColonyClient;
+  colonyRoles: ColonyRoles;
 }
 
 export const ColonyContext = createContext({} as State);
@@ -34,6 +36,7 @@ function ColonyProvider({ children }: Props) {
   /** State Variables **/
   const [colonyClient, setColonyClient] = useState<ColonyClient>();
   const [networkClient, setNetworkClient] = useState<NetworkClient>();
+  const [colonyRoles, setColonyRoles] = useState<ColonyRoles>([]);
 
   const network = "mainnet";
   useEffect(() => {
@@ -73,7 +76,15 @@ function ColonyProvider({ children }: Props) {
     if (process.env.REACT_APP_COLONY_ENS_NAME) setColony(process.env.REACT_APP_COLONY_ENS_NAME);
   }, [setColony]);
 
-  return <ColonyContext.Provider value={{ colonyClient, setColony }}>{children}</ColonyContext.Provider>;
+  useEffect(() => {
+    if (colonyClient) {
+      getColonyRoles(colonyClient).then((newRoles: ColonyRoles) => setColonyRoles(newRoles));
+    } else {
+      setColonyRoles([]);
+    }
+  }, [colonyClient]);
+
+  return <ColonyContext.Provider value={{ colonyClient, colonyRoles, setColony }}>{children}</ColonyContext.Provider>;
 }
 
 export const useColonyClient = (): ColonyClient | undefined => {
@@ -84,6 +95,32 @@ export const useColonyClient = (): ColonyClient | undefined => {
 export const useSetColony = (): Function => {
   const { setColony } = useColonyContext();
   return setColony;
+};
+
+export const useColonyRoles = (): ColonyRoles => {
+  const { colonyRoles } = useColonyContext();
+
+  return colonyRoles;
+};
+
+export const useHasDomainPermission = (
+  userAddress: string | undefined,
+  domainId: number,
+  role: ColonyRole,
+): boolean => {
+  const colonyRoles = useColonyRoles();
+
+  const hasPermission = useMemo(() => {
+    // Check if user has selected role (or root)
+    const rootOnDomain = userHasDomainRole(colonyRoles, userAddress, domainId, ColonyRole.Root);
+    const roleOnDomain = userHasDomainRole(colonyRoles, userAddress, domainId, role);
+    // The user could also inherit this role from the root domain
+    const rootOnRoot = userHasDomainRole(colonyRoles, userAddress, 1, ColonyRole.Root);
+    const roleOnRoot = userHasDomainRole(colonyRoles, userAddress, 1, role);
+    return rootOnDomain || roleOnDomain || rootOnRoot || roleOnRoot;
+  }, [colonyRoles, userAddress, domainId, role]);
+
+  return hasPermission;
 };
 
 export const useColonyVersion = (): BigNumber => {
@@ -164,47 +201,6 @@ export const useTokensInfo = () => {
   }, [colonyClient, tokens]);
 
   return tokensInfo;
-};
-
-export const useColonyRoles = (): ColonyRoles => {
-  const colonyClient = useColonyClient();
-  const [roles, setRoles] = useState<ColonyRoles>([]);
-
-  useEffect(() => {
-    if (colonyClient) {
-      getColonyRoles(colonyClient).then((newRoles: ColonyRoles) => setRoles(newRoles));
-    } else {
-      setRoles([]);
-    }
-  }, [colonyClient]);
-
-  return roles;
-};
-
-export const useHasDomainPermission = (
-  userAddress: string | undefined,
-  domainId: number,
-  role: ColonyRole,
-): boolean => {
-  const colonyClient = useColonyClient();
-  const [hasPermission, setHasPermission] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (userAddress && colonyClient) {
-      Promise.all([
-        // Check if user has selected role (or root)
-        colonyClient.hasUserRole(userAddress, domainId, ColonyRole.Root),
-        colonyClient.hasUserRole(userAddress, domainId, role),
-        // The user could also inherit this permission from the root domain
-        colonyClient.hasUserRole(userAddress, 1, ColonyRole.Root),
-        colonyClient.hasUserRole(userAddress, 1, role),
-      ]).then(roleStatuses => setHasPermission(roleStatuses.includes(true)));
-    } else {
-      setHasPermission(false);
-    }
-  }, [colonyClient, userAddress, domainId, role]);
-
-  return hasPermission;
 };
 
 export default ColonyProvider;

--- a/src/contexts/ColonyContext.tsx
+++ b/src/contexts/ColonyContext.tsx
@@ -1,6 +1,13 @@
 import React, { useState, createContext, ReactElement, useContext, useCallback, useEffect } from "react";
 
-import { getColonyNetworkClient, Network, ColonyClient, NetworkClient } from "@colony/colony-js";
+import {
+  getColonyNetworkClient,
+  Network,
+  ColonyClient,
+  NetworkClient,
+  ColonyRoles,
+  getColonyRoles,
+} from "@colony/colony-js";
 import getTokenClient, { TokenInfo } from "@colony/colony-js/lib/clients/TokenClient";
 import { InfuraProvider } from "ethers/providers";
 import { BigNumber } from "ethers/utils";
@@ -156,6 +163,21 @@ export const useTokensInfo = () => {
   }, [colonyClient, tokens]);
 
   return tokensInfo;
+};
+
+export const useColonyRoles = (): ColonyRoles => {
+  const colonyClient = useColonyClient();
+  const [roles, setRoles] = useState<ColonyRoles>([]);
+
+  useEffect(() => {
+    if (colonyClient) {
+      getColonyRoles(colonyClient).then((newRoles: ColonyRoles) => setRoles(newRoles));
+    } else {
+      setRoles([]);
+    }
+  }, [colonyClient]);
+
+  return roles;
 };
 
 export default ColonyProvider;

--- a/src/pages/ColonyPage.tsx
+++ b/src/pages/ColonyPage.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import { useTokensInfo } from "../contexts/ColonyContext";
 
-import SetRewardsModal from "../components/Modals/SetRewardsModal.tsx";
+import PayoutSidebar from "../components/PayoutList/Sidebar";
 import DomainTree from "../components/ColonyTree/DomainTree";
 import ColonyTree from "../components/ColonyTree";
 import TokenList from "../components/TokenList";
@@ -83,7 +83,7 @@ const ColonyPage = () => {
         </TabPanel>
         <TabPanel value={currentTab} index={TabsLabels.Rewards}>
           <LeftWrapper>
-            <SetRewardsModal />
+            <PayoutSidebar />
           </LeftWrapper>
           <PayoutList tokens={tokens} />
         </TabPanel>

--- a/src/pages/ColonyPage.tsx
+++ b/src/pages/ColonyPage.tsx
@@ -33,9 +33,9 @@ const TabContentsWrapper = styled.div`
 const LeftWrapper = styled.div`
   display: flex;
   flex-flow: column nowrap;
-  align-items: flex-start;
-
-  min-width: 140px;
+  align-items: flex-end;
+  margin-right: 16px
+  width: 140px;
 `;
 
 function TabPanel(props: any) {

--- a/src/utils/colony/userHasDomainRole.ts
+++ b/src/utils/colony/userHasDomainRole.ts
@@ -1,0 +1,24 @@
+import { ColonyRoles, ColonyRole, UserRoles, DomainRoles } from "@colony/colony-js";
+
+const userHasDomainRole = (
+  colonyRoles: ColonyRoles,
+  userAddress: string | undefined,
+  domain: number,
+  role: ColonyRole,
+) => {
+  try {
+    // Find all roles of address of interest
+    const userRoles: UserRoles | undefined = colonyRoles.find(
+      ({ address }: { address: string }) => address === userAddress,
+    );
+    // Find their roles on the domain of interest
+    const domainRoles: DomainRoles | undefined = userRoles?.domains.find(
+      ({ domainId }: { domainId: number }) => domainId === domain,
+    );
+    return domainRoles?.roles.includes(role) || false;
+  } catch (e) {
+    return false;
+  }
+};
+
+export default userHasDomainRole;


### PR DESCRIPTION
This PR begins to lock down certain UI elements based on their permissions on the colony to avoid the bad UX of failed transactions. To do this I've set the `ColonyContext` to query the full list of colony permissions upon first load which is then persisted, we can then make permission queries entirely offline from that point onward improving load speeds. 

This is done using the `useHasDomainPermission` (I'd welcome a better name) hook which checks whether the user has a given permission (or root permissions) within the desired domain or in the root domain. I've added these hooks in the required locations and disabled features where they are implemented or added feedback ready for when we implement them. Choices on which roles to require for a given element have been taken from https://colony.io/dev/docs/colonyjs/topics-colony-roles.

- [x] Add an element to give a new address permissions on the colony (only visible with Root permission)
- [x] Don't open PermissionsModal without Root permission
- [x] Add explanatory tooltip for users without Root permission attempting to do so.
- [x] Disable moving tokens to a different pot without Funding permission.
- [x] Disable sending tokens to an address without Root permission.
- [x] Disable minting colony tokens without Root permission.
- [x] Disable "Set Rewards %" button without Root Permission
- [x] Add "Lock/Unlock Tokens" button