### PR TITLE
refactor sidebar so that it is inside each tab

### DIFF
--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -5,6 +5,7 @@ import PayoutModal from "../Modals/PayoutModal";
 import { Token } from "../../typings";
 
 const StyledTable = styled(Table)`
+  min-width: 480px;
   box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
 `;
 

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -10,7 +10,7 @@ import Address from "../common/Address";
 import { useColonyClient } from "../../contexts/ColonyContext";
 
 const StyledTable = styled(Table)`
-  min-width: 450px;
+  min-width: 480px;
   box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
 `;
 

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -8,7 +8,7 @@ import { useSafeInfo } from "../../contexts/SafeContext";
 import { Token } from "../../typings";
 
 const StyledTable = styled(Table)`
-  min-width: 450px;
+  min-width: 480px;
   box-shadow: 1px 2px 10px 0 rgba(212, 212, 211, 0.59);
 `;
 

--- a/src/pages/ColonyPage.tsx
+++ b/src/pages/ColonyPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useState, ChangeEvent } from "react";
-import { Tabs, Tab, Box } from "@material-ui/core";
+import { Tabs, Tab } from "@material-ui/core";
 import styled from "styled-components";
 
 import { useTokensInfo } from "../contexts/ColonyContext";
@@ -19,69 +19,72 @@ const OuterWrapper = styled.div`
   width: calc(100% - 48px);
 `;
 
+const TabsWrapper = styled.div`
+  display: flex;
+  align-items: flex-end;
+  flex-flow: column nowrap;
+`;
+
+const TabContentsWrapper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+`;
+
 const LeftWrapper = styled.div`
   display: flex;
   flex-flow: column nowrap;
-  min-width: 120px;
+  align-items: flex-start;
 
-  :first-child {
-    margin-top: 80px;
-  }
-`;
-
-const TabsWrapper = styled.div`
-  display: flex;
-  flex-flow: column nowrap;
+  min-width: 140px;
 `;
 
 function TabPanel(props: any) {
   const { children, value, index, ...other } = props;
 
   return (
-    <div hidden={value !== index} {...other}>
-      {value === index && <Box p={3}>{children}</Box>}
-    </div>
+    <TabContentsWrapper hidden={value !== index} {...other}>
+      {value === index && <>{children}</>}
+    </TabContentsWrapper>
   );
 }
 
-const SideBar = ({ currentTab }: { currentTab: number }) => {
-  switch (currentTab) {
-    case 0:
-      return <ColonyTree />;
-    case 1:
-      return <DomainTree />;
-    case 2:
-      return <SetRewardsModal />;
-    default:
-      return null;
-  }
-};
+enum TabsLabels {
+  Tokens = 0,
+  Permissions,
+  Rewards,
+}
 
 const ColonyPage = () => {
   const tokens = useTokensInfo();
   /** State Variables **/
-  const [currentTab, setCurrentTab] = useState<number>(0);
+  const [currentTab, setCurrentTab] = useState<TabsLabels>(0);
 
   const handleChange = (_event: ChangeEvent<{}>, newValue: number) => setCurrentTab(newValue);
 
   return (
     <OuterWrapper>
-      <LeftWrapper>
-        <SideBar currentTab={currentTab} />
-      </LeftWrapper>
       <TabsWrapper>
-        <Tabs variant="fullWidth" value={currentTab} onChange={handleChange}>
+        <Tabs value={currentTab} onChange={handleChange}>
           <Tab label="Tokens" />
           <Tab label="Permissions" />
           <Tab label="Rewards" />
         </Tabs>
-        <TabPanel value={currentTab} index={0}>
+        <TabPanel value={currentTab} index={TabsLabels.Tokens}>
+          <LeftWrapper>
+            <ColonyTree />
+          </LeftWrapper>
           <TokenList tokens={tokens} />
         </TabPanel>
-        <TabPanel value={currentTab} index={1}>
+        <TabPanel value={currentTab} index={TabsLabels.Permissions}>
+          <LeftWrapper>
+            <DomainTree />
+          </LeftWrapper>
           <PermissionsList />
         </TabPanel>
-        <TabPanel value={currentTab} index={2}>
+        <TabPanel value={currentTab} index={TabsLabels.Rewards}>
+          <LeftWrapper>
+            <SetRewardsModal />
+          </LeftWrapper>
           <PayoutList tokens={tokens} />
         </TabPanel>
       </TabsWrapper>


### PR DESCRIPTION
Previously the sidebar was a separate component which used the current tab state variable independently to how the rest of the tab's contents was displayed.

I've changed this so that the sidebar sits within each tab so that the relevant sidebar is chosen through the same logic as the rest of the display. Using this method also simplifies aligning the sidebar with the tab contents