### PR TITLE
Add support for viewing multiple domains

### DIFF
--- a/src/components/ColonyTree/DomainTree.tsx
+++ b/src/components/ColonyTree/DomainTree.tsx
@@ -1,15 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
-
-import { ColonyClient } from "@colony/colony-js";
 
 import TreeView from "@material-ui/lab/TreeView";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import ArrowRightIcon from "@material-ui/icons/ArrowRight";
-import { useColonyClient } from "../../contexts/ColonyContext";
-import getColonyDomains from "../../utils/colony/getColonyDomains";
-import { Domain } from "../../typings";
 import DomainTreeItems from "./DomainTreeItems";
+import { useColonyDomains } from "../../contexts/ColonyContext";
 
 const useStyles = makeStyles({
   root: {
@@ -19,26 +15,36 @@ const useStyles = makeStyles({
   },
 });
 
-export default function DomainTree() {
-  const colonyClient: ColonyClient | undefined = useColonyClient();
-  const [domains, setDomains] = useState<Domain[]>([]);
+export default function DomainTree({
+  currentDomainId,
+  setCurrentDomainId,
+}: {
+  currentDomainId: number;
+  setCurrentDomainId: Function;
+}) {
+  const domains = useColonyDomains();
   const classes = useStyles();
+  const [expanded, setExpanded] = useState<string[]>([]);
 
-  useEffect(() => {
-    if (colonyClient) {
-      getColonyDomains(colonyClient).then((newDomains: Domain[]) => setDomains(newDomains));
-    } else {
-      setDomains([]);
-    }
-  }, [colonyClient]);
+  const handleToggle = (_event: any, nodeIds: string[]) => {
+    setExpanded(nodeIds);
+  };
+
+  const handleSelect = (_event: any, nodeIds: string[]) => {
+    setCurrentDomainId(parseInt(nodeIds.toString(), 10));
+  };
 
   return (
     <TreeView
       className={classes.root}
-      defaultExpanded={["0"]}
+      defaultExpanded={["1"]}
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
+      expanded={expanded}
+      selected={[currentDomainId.toString()]}
+      onNodeToggle={handleToggle}
+      onNodeSelect={handleSelect}
     >
       <DomainTreeItems domains={domains} />
     </TreeView>

--- a/src/components/ColonyTree/DomainTreeItems.tsx
+++ b/src/components/ColonyTree/DomainTreeItems.tsx
@@ -3,15 +3,15 @@ import React from "react";
 import StyledTreeItem from "./StyledTreeItem";
 import { Domain } from "../../typings";
 
-const DomainTreeItems = ({ domains, startNoteId = 1 }: { domains: Domain[]; startNoteId?: number }) => {
+const DomainTreeItems = ({ domains, startNodeId = 1 }: { domains: Domain[]; startNodeId?: number }) => {
   if (domains.length === 0) return null;
-  if (domains.length === 1) return <StyledTreeItem nodeId={startNoteId.toString()} labelText="Root Domain" />;
+  if (domains.length === 1) return <StyledTreeItem nodeId={startNodeId.toString()} labelText="Root Domain" />;
 
   return (
-    <StyledTreeItem nodeId={startNoteId.toString()} labelText="Root Domain">
+    <StyledTreeItem nodeId={startNodeId.toString()} labelText="Root Domain">
       {domains.slice(1).map((_domain: Domain, index: number) => {
         const domainNumber = index + 1;
-        const nodeId = startNoteId + domainNumber;
+        const nodeId = startNodeId + domainNumber;
         return (
           // eslint-disable-next-line react/no-array-index-key
           <StyledTreeItem key={domainNumber} nodeId={nodeId.toString()} labelText={`Domain #${domainNumber}`} />

--- a/src/components/ColonyTree/DomainTreeItems.tsx
+++ b/src/components/ColonyTree/DomainTreeItems.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import StyledTreeItem from "./StyledTreeItem";
 import { Domain } from "../../typings";
 
-const DomainTreeItems = ({ domains, startNoteId = 0 }: { domains: Domain[]; startNoteId?: number }) => {
+const DomainTreeItems = ({ domains, startNoteId = 1 }: { domains: Domain[]; startNoteId?: number }) => {
   if (domains.length === 0) return null;
   if (domains.length === 1) return <StyledTreeItem nodeId={startNoteId.toString()} labelText="Root Domain" />;
 

--- a/src/components/ColonyTree/index.tsx
+++ b/src/components/ColonyTree/index.tsx
@@ -1,14 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import TreeView from "@material-ui/lab/TreeView";
 import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
 import ArrowRightIcon from "@material-ui/icons/ArrowRight";
-import { ColonyClient } from "@colony/colony-js";
 import StyledTreeItem from "./StyledTreeItem";
-import getColonyDomains from "../../utils/colony/getColonyDomains";
-import { Domain } from "../../typings";
-import { useColonyClient } from "../../contexts/ColonyContext";
 import DomainTreeItems from "./DomainTreeItems";
+import { useColonyDomains } from "../../contexts/ColonyContext";
+import { ALL_DOMAINS_ID, REWARDS_FUNDING_POT_ID } from "../../constants";
 
 const useStyles = makeStyles({
   root: {
@@ -18,30 +16,41 @@ const useStyles = makeStyles({
   },
 });
 
-export default function ColonyTree() {
-  const colonyClient: ColonyClient | undefined = useColonyClient();
-  const [domains, setDomains] = useState<Domain[]>([]);
+export default function ColonyTree({
+  currentDomainId,
+  setCurrentDomainId,
+}: {
+  currentDomainId: number;
+  setCurrentDomainId: Function;
+}) {
+  const domains = useColonyDomains();
   const classes = useStyles();
 
-  useEffect(() => {
-    if (colonyClient) {
-      getColonyDomains(colonyClient).then((newDomains: Domain[]) => setDomains(newDomains));
-    } else {
-      setDomains([]);
-    }
-  }, [colonyClient]);
+  const [expanded, setExpanded] = useState<string[]>([]);
 
+  const handleToggle = (_event: any, nodeIds: string[]) => {
+    setExpanded(nodeIds);
+  };
+
+  const handleSelect = (_event: any, nodeIds: string[]) => {
+    console.log(nodeIds);
+    setCurrentDomainId(parseInt(nodeIds.toString(), 10));
+  };
   return (
     <TreeView
       className={classes.root}
-      defaultExpanded={["3"]}
+      defaultExpanded={["0"]}
       defaultCollapseIcon={<ArrowDropDownIcon />}
       defaultExpandIcon={<ArrowRightIcon />}
       defaultEndIcon={<div style={{ width: 24 }} />}
+      expanded={expanded}
+      selected={[currentDomainId.toString()]}
+      onNodeToggle={handleToggle}
+      onNodeSelect={handleSelect}
     >
-      <StyledTreeItem nodeId="1" labelText="Entire Colony" />
-      <StyledTreeItem nodeId="2" labelText="Rewards Pot" />
-      <DomainTreeItems domains={domains} startNoteId={3} />
+      <StyledTreeItem nodeId={ALL_DOMAINS_ID.toString()} labelText="Entire Colony" />
+      <StyledTreeItem nodeId={REWARDS_FUNDING_POT_ID.toString()} labelText="Rewards Pot" />
+      <DomainTreeItems domains={domains} />
     </TreeView>
   );
 }

--- a/src/components/ColonyTree/index.tsx
+++ b/src/components/ColonyTree/index.tsx
@@ -33,7 +33,6 @@ export default function ColonyTree({
   };
 
   const handleSelect = (_event: any, nodeIds: string[]) => {
-    console.log(nodeIds);
     setCurrentDomainId(parseInt(nodeIds.toString(), 10));
   };
   return (

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -1,17 +1,31 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { TableRow, TableCell } from "@material-ui/core";
+import { formatUnits } from "ethers/utils";
 import Table from "../common/StyledTable";
 import PayoutModal from "../Modals/PayoutModal";
 import { Token } from "../../typings";
+import { useColonyClient } from "../../contexts/ColonyContext";
+import { REWARDS_FUNDING_POT_ID } from "../../constants";
 
 const TokenRow = ({ token }: { token: Token }) => {
+  const colonyClient = useColonyClient();
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [balance, setBalance] = useState<string>("0");
+
+  useEffect(() => {
+    if (colonyClient) {
+      colonyClient
+        .getFundingPotBalance(REWARDS_FUNDING_POT_ID, token.address)
+        .then(tokenBalance => setBalance(tokenBalance.toString()));
+    }
+  }, [colonyClient, token.address]);
+
   return (
     <>
       <PayoutModal isOpen={isOpen} setIsOpen={setIsOpen} token={token} />
       <TableRow onClick={() => setIsOpen(true)}>
         <TableCell>{token.symbol}</TableCell>
-        <TableCell align="right">0.000</TableCell>
+        <TableCell align="right">{formatUnits(balance, token.decimals)}</TableCell>
       </TableRow>
     </>
   );

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -85,17 +85,26 @@ const AddAddressRow = () => {
   );
 };
 
-const PermissionsList = () => {
+const PermissionsList = ({ currentDomainId }: { currentDomainId: number }) => {
   const safeInfo = useSafeInfo();
-  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
+  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, currentDomainId, ColonyRole.Root);
   const roles: ColonyRoles = useColonyRoles();
 
   const addressList = useMemo(
     () =>
       roles.map(({ address, domains }) => (
-        <AddressRow address={address} permissions={domains[0]} hasRootPermission={hasRootPermission} />
+        <AddressRow
+          address={address}
+          permissions={
+            domains.find(({ domainId }: { domainId: number }) => domainId === currentDomainId) || {
+              domainId: currentDomainId,
+              roles: [],
+            }
+          }
+          hasRootPermission={hasRootPermission}
+        />
       )),
-    [roles, hasRootPermission],
+    [roles, hasRootPermission, currentDomainId],
   );
 
   return (

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -8,7 +8,7 @@ import TokenModal from "../Modals/TokenModal";
 import { useHasDomainPermission, useColonyClient, useColonyDomains } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
 import { Token, Domain } from "../../typings";
-import { ALL_DOMAINS_ID } from "../../constants";
+import { ALL_DOMAINS_ID, REWARDS_FUNDING_POT_ID } from "../../constants";
 
 const TokenRow = ({
   token,
@@ -32,6 +32,10 @@ const TokenRow = ({
     if (colonyClient) {
       if (domainId === ALL_DOMAINS_ID) {
         colonyClient.getNonRewardPotsTotal(token.address).then(tokenBalance => setBalance(tokenBalance.toString()));
+      } else if (domainId === REWARDS_FUNDING_POT_ID) {
+        colonyClient
+          .getFundingPotBalance(REWARDS_FUNDING_POT_ID, token.address)
+          .then(tokenBalance => setBalance(tokenBalance.toString()));
       } else {
         const domainInfo = colonyDomains.find((domain: Domain) => domainId === domain.domainId.toNumber());
         if (domainInfo) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export const ALL_DOMAINS_ID = -1;
+export const REWARDS_FUNDING_POT_ID = 0;

--- a/src/pages/ColonyPage.tsx
+++ b/src/pages/ColonyPage.tsx
@@ -58,6 +58,7 @@ const ColonyPage = () => {
   const tokens = useTokensInfo();
   /** State Variables **/
   const [currentTab, setCurrentTab] = useState<TabsLabels>(0);
+  const [currentDomainId, setCurrentDomainId] = useState<number>(1);
 
   const handleChange = (_event: ChangeEvent<{}>, newValue: number) => setCurrentTab(newValue);
 
@@ -71,15 +72,15 @@ const ColonyPage = () => {
         </Tabs>
         <TabPanel value={currentTab} index={TabsLabels.Tokens}>
           <LeftWrapper>
-            <ColonyTree />
+            <ColonyTree currentDomainId={currentDomainId} setCurrentDomainId={setCurrentDomainId} />
           </LeftWrapper>
-          <TokenList tokens={tokens} />
+          <TokenList tokens={tokens} currentDomainId={currentDomainId} />
         </TabPanel>
         <TabPanel value={currentTab} index={TabsLabels.Permissions}>
           <LeftWrapper>
-            <DomainTree />
+            <DomainTree currentDomainId={currentDomainId} setCurrentDomainId={setCurrentDomainId} />
           </LeftWrapper>
-          <PermissionsList />
+          <PermissionsList currentDomainId={Math.max(currentDomainId, 1)} />
         </TabPanel>
         <TabPanel value={currentTab} index={TabsLabels.Rewards}>
           <LeftWrapper>

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -13,4 +13,11 @@ export type Transaction = {
   value: BigNumberish;
 };
 
-export type Domain = { skillId: BigNumber; fundingPotId: BigNumber; 0: BigNumber; 1: BigNumber };
+export type Domain = {
+  skillId: BigNumber;
+  fundingPotId: BigNumber;
+  domainId: BigNumber;
+  0: BigNumber;
+  1: BigNumber;
+  2: BigNumber;
+};

--- a/src/utils/colony/getColonyDomains.ts
+++ b/src/utils/colony/getColonyDomains.ts
@@ -6,7 +6,7 @@ const getColonyDomains = async (client: ColonyClient): Promise<Domain[]> => {
 
   // Domains are 1 indexed so we add a shift
   const domainIdArray = Array.from(Array(domainCount.toNumber()), (_, i) => i + 1);
-  return Promise.all(domainIdArray.map(domainIndex => client.getDomain(domainIndex + 1)));
+  return Promise.all(domainIdArray.map(domainIndex => client.getDomain(domainIndex)));
 };
 
 export default getColonyDomains;

--- a/src/utils/colony/getColonyDomains.ts
+++ b/src/utils/colony/getColonyDomains.ts
@@ -1,4 +1,5 @@
 import { ColonyClient } from "@colony/colony-js";
+import { BigNumber } from "ethers/utils";
 import { Domain } from "../../typings";
 
 const getColonyDomains = async (client: ColonyClient): Promise<Domain[]> => {
@@ -6,7 +7,15 @@ const getColonyDomains = async (client: ColonyClient): Promise<Domain[]> => {
 
   // Domains are 1 indexed so we add a shift
   const domainIdArray = Array.from(Array(domainCount.toNumber()), (_, i) => i + 1);
-  return Promise.all(domainIdArray.map(domainIndex => client.getDomain(domainIndex)));
+  return Promise.all(
+    domainIdArray.map(
+      async (domainId: number): Promise<Domain> => ({
+        ...(await client.getDomain(domainId)),
+        domainId: new BigNumber(domainId),
+        2: new BigNumber(domainId),
+      }),
+    ),
+  );
 };
 
 export default getColonyDomains;


### PR DESCRIPTION
This PR adds support for users to choose which domain they want to view data for through the sidebar.

To test this I've also added logic to query and display token balances for each domain/rewards pots.