### PR TITLE
Unify tabs to all have special action at the top.

### DIFF
--- a/src/components/Modals/PayoutModal/ModalFooter.tsx
+++ b/src/components/Modals/PayoutModal/ModalFooter.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Button } from "@gnosis.pm/safe-react-components";
+import styled from "styled-components";
+
+const FooterWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+`;
+
+type Props = {
+  okText?: string;
+  cancelText?: string;
+  okDisabled?: boolean;
+  handleOk: () => void;
+  handleCancel: () => void;
+};
+
+const ModalFooter = ({ cancelText = "Cancel", handleCancel, okDisabled, handleOk, okText = "Confirm" }: Props) => {
+  return (
+    <FooterWrapper>
+      <Button size="md" color="secondary" variant="contained" onClick={handleCancel}>
+        {cancelText}
+      </Button>
+      <Button size="md" color="primary" variant="contained" onClick={handleOk} disabled={okDisabled}>
+        {okText}
+      </Button>
+    </FooterWrapper>
+  );
+};
+
+export default ModalFooter;

--- a/src/components/Modals/PayoutModal/index.tsx
+++ b/src/components/Modals/PayoutModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from "react";
-import { GenericModal, ModalFooterConfirmation, Text } from "@gnosis.pm/safe-react-components";
+import { GenericModal, Text } from "@gnosis.pm/safe-react-components";
+import ModalFooter from "./ModalFooter";
 import { Token } from "../../../typings";
 
 const PayoutModal = ({
@@ -18,13 +19,14 @@ const PayoutModal = ({
   );
 
   const modalFooter = (
-    <ModalFooterConfirmation
-      okText="Save"
-      // okDisabled={false}
-      handleCancel={() => setIsOpen(false)}
-      handleOk={() => console.log("Clicked ok!")}
+    <ModalFooter
+      cancelText="Waive"
+      okText="Claim"
+      handleCancel={() => console.log("Waiving Reward!")}
+      handleOk={() => console.log("Claiming Reward!")}
     />
   );
+
   if (!isOpen) return null;
   return (
     <GenericModal

--- a/src/components/Modals/TokenModal/TokenModalBody.tsx
+++ b/src/components/Modals/TokenModal/TokenModalBody.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { Text, TextField } from "@gnosis.pm/safe-react-components";
+import { Text } from "@gnosis.pm/safe-react-components";
 import { Tabs, Tab, Box } from "@material-ui/core";
 import { Token } from "../../../typings";
 
@@ -16,45 +16,37 @@ function TabPanel(props: any) {
 
 const TokenModalBody = ({
   token,
-  hasRootRole,
   hasAdministrationRole,
   hasFundingRole,
   currentTab,
   handleChangeTab,
-  amount,
-  handleChangeAmount,
+  _amount,
+  _handleChangeAmount,
 }: {
   token: Token;
-  hasRootRole: boolean;
   hasAdministrationRole: boolean;
   hasFundingRole: boolean;
   currentTab: number;
   handleChangeTab: (_event: any, newValue: number) => void;
-  amount: string;
-  handleChangeAmount: (_event: any) => void;
+  _amount: string;
+  _handleChangeAmount: (_event: any) => void;
 }): ReactElement => (
   <>
     <Text size="lg">{`This is the ${token.symbol} modal`}</Text>
-    <Text size="lg">{hasRootRole ? "This user can mint colony tokens" : "This user can't mint colony tokens"}</Text>
-    <Text size="lg">
-      {hasAdministrationRole ? "This user can initiate payments" : "This user can't initiate payments"}
-    </Text>
-    <Text size="lg">
-      {hasFundingRole ? "This user can transfer funds between pots" : "This user can't transfer funds between pots"}
-    </Text>
+
     <Tabs variant="fullWidth" value={currentTab} onChange={handleChangeTab}>
       <Tab label="Move" />
       <Tab label="Send" />
-      <Tab label="Mint" />
     </Tabs>
     <TabPanel value={currentTab} index={0}>
-      Move
+      <Text size="lg">
+        {hasFundingRole ? "This user can transfer funds between pots" : "This user can't transfer funds between pots"}
+      </Text>
     </TabPanel>
     <TabPanel value={currentTab} index={1}>
-      Send
-    </TabPanel>
-    <TabPanel value={currentTab} index={2}>
-      Amount <TextField label="Mint Amount" value={amount} onChange={handleChangeAmount} />
+      <Text size="lg">
+        {hasAdministrationRole ? "This user can initiate payments" : "This user can't initiate payments"}
+      </Text>
     </TabPanel>
   </>
 );

--- a/src/components/Modals/TokenModal/TokenModalBody.tsx
+++ b/src/components/Modals/TokenModal/TokenModalBody.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement } from "react";
+import { Text, TextField } from "@gnosis.pm/safe-react-components";
+import { Tabs, Tab, Box } from "@material-ui/core";
+import { Token } from "../../../typings";
+
+function TabPanel(props: any) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <div hidden={value !== index} {...other}>
+      {value === index && <Box p={3}>{children}</Box>}
+    </div>
+  );
+}
+
+const TokenModalBody = ({
+  token,
+  hasRootRole,
+  hasAdministrationRole,
+  hasFundingRole,
+  currentTab,
+  handleChangeTab,
+  amount,
+  handleChangeAmount,
+}: {
+  token: Token;
+  hasRootRole: boolean;
+  hasAdministrationRole: boolean;
+  hasFundingRole: boolean;
+  currentTab: number;
+  handleChangeTab: (_event: any, newValue: number) => void;
+  amount: string;
+  handleChangeAmount: (_event: any) => void;
+}): ReactElement => (
+  <>
+    <Text size="lg">{`This is the ${token.symbol} modal`}</Text>
+    <Text size="lg">{hasRootRole ? "This user can mint colony tokens" : "This user can't mint colony tokens"}</Text>
+    <Text size="lg">
+      {hasAdministrationRole ? "This user can initiate payments" : "This user can't initiate payments"}
+    </Text>
+    <Text size="lg">
+      {hasFundingRole ? "This user can transfer funds between pots" : "This user can't transfer funds between pots"}
+    </Text>
+    <Tabs variant="fullWidth" value={currentTab} onChange={handleChangeTab}>
+      <Tab label="Move" />
+      <Tab label="Send" />
+      <Tab label="Mint" />
+    </Tabs>
+    <TabPanel value={currentTab} index={0}>
+      Move
+    </TabPanel>
+    <TabPanel value={currentTab} index={1}>
+      Send
+    </TabPanel>
+    <TabPanel value={currentTab} index={2}>
+      Amount <TextField label="Mint Amount" value={amount} onChange={handleChangeAmount} />
+    </TabPanel>
+  </>
+);
+
+export default TokenModalBody;

--- a/src/components/Modals/TokenModal/index.tsx
+++ b/src/components/Modals/TokenModal/index.tsx
@@ -1,6 +1,7 @@
-import React, { ReactElement } from "react";
-import { Text, ModalFooterConfirmation, GenericModal } from "@gnosis.pm/safe-react-components";
+import React, { ReactElement, useState } from "react";
+import { ModalFooterConfirmation, GenericModal } from "@gnosis.pm/safe-react-components";
 import { Token } from "../../../typings";
+import TokenModalBody from "./TokenModalBody";
 
 const TokenModal = ({
   isOpen,
@@ -17,20 +18,14 @@ const TokenModal = ({
   hasAdministrationRole: boolean;
   hasFundingRole: boolean;
 }): ReactElement | null => {
-  const modalTitle = `${token.symbol}`;
+  /** State Variables **/
+  const [currentTab, setCurrentTab] = useState<number>(0);
+  const [amount, setAmount] = useState<string>("");
 
-  const modalBody = (
-    <>
-      <Text size="lg">{`This is the ${token.symbol} modal`}</Text>
-      <Text size="lg">{hasRootRole ? "This user can mint colony tokens" : "This user can't mint colony tokens"}</Text>
-      <Text size="lg">
-        {hasAdministrationRole ? "This user can initiate payments" : "This user can't initiate payments"}
-      </Text>
-      <Text size="lg">
-        {hasFundingRole ? "This user can transfer funds between pots" : "This user can't transfer funds between pots"}
-      </Text>
-    </>
-  );
+  const handleChangeAmount = (event: any) => setAmount(event.target.value);
+  const handleChangeTab = (_event: any, newValue: number) => setCurrentTab(newValue);
+
+  const modalTitle = `${token.symbol}`;
 
   const modalFooter = (
     <ModalFooterConfirmation
@@ -42,7 +37,25 @@ const TokenModal = ({
   );
 
   if (!isOpen) return null;
-  return <GenericModal onClose={() => setIsOpen(false)} title={modalTitle} body={modalBody} footer={modalFooter} />;
+  return (
+    <GenericModal
+      onClose={() => setIsOpen(false)}
+      title={modalTitle}
+      body={
+        <TokenModalBody
+          currentTab={currentTab}
+          handleChangeTab={handleChangeTab}
+          amount={amount}
+          handleChangeAmount={handleChangeAmount}
+          token={token}
+          hasRootRole={hasRootRole}
+          hasAdministrationRole={hasAdministrationRole}
+          hasFundingRole={hasFundingRole}
+        />
+      }
+      footer={modalFooter}
+    />
+  );
 };
 
 export default TokenModal;

--- a/src/components/Modals/TokenModal/index.tsx
+++ b/src/components/Modals/TokenModal/index.tsx
@@ -7,14 +7,12 @@ const TokenModal = ({
   isOpen,
   setIsOpen,
   token,
-  hasRootRole,
   hasAdministrationRole,
   hasFundingRole,
 }: {
   isOpen: boolean;
   setIsOpen: Function;
   token: Token;
-  hasRootRole: boolean;
   hasAdministrationRole: boolean;
   hasFundingRole: boolean;
 }): ReactElement | null => {
@@ -45,10 +43,9 @@ const TokenModal = ({
         <TokenModalBody
           currentTab={currentTab}
           handleChangeTab={handleChangeTab}
-          amount={amount}
-          handleChangeAmount={handleChangeAmount}
+          _amount={amount}
+          _handleChangeAmount={handleChangeAmount}
           token={token}
-          hasRootRole={hasRootRole}
           hasAdministrationRole={hasAdministrationRole}
           hasFundingRole={hasFundingRole}
         />

--- a/src/components/PayoutList/Sidebar.tsx
+++ b/src/components/PayoutList/Sidebar.tsx
@@ -1,17 +1,21 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { ColonyRole } from "@colony/colony-js";
 import { Button, Text } from "@gnosis.pm/safe-react-components";
-import { useHasDomainPermission } from "../../contexts/ColonyContext";
+import { BigNumber } from "ethers/utils";
+import { useHasDomainPermission, useRewardInverse } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
 import SetRewardsModal from "../Modals/SetRewardsModal";
 
 const PayoutSidebar = () => {
   const safeInfo = useSafeInfo();
+  const rewardsInverse = useRewardInverse();
   const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
+
+  const rewardsPercentage = useMemo(() => new BigNumber(100).div(rewardsInverse), [rewardsInverse]);
 
   return (
     <>
-      <Text size="md">20% of all incoming revenue is contributed to the rewards pot</Text>
+      <Text size="md">{`${rewardsPercentage}% of all incoming revenue is contributed to the rewards pot`}</Text>
       <SetRewardsModal disabled={!hasRootPermission} />
       <Button size="md" color="primary" onClick={() => console.log("Opening Lock/Unlock Tokens")}>
         Lock/Unlock Tokens

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -5,11 +5,16 @@ import { TableRow, TableCell } from "@material-ui/core";
 import { Text, Icon } from "@gnosis.pm/safe-react-components";
 import styled from "styled-components";
 
+import { ColonyRole } from "@colony/colony-js";
 import Table from "../common/StyledTable";
 import PayoutModal from "../Modals/PayoutModal";
-import { Token } from "../../typings";
-import { useColonyClient } from "../../contexts/ColonyContext";
+
+import { useSafeInfo } from "../../contexts/SafeContext";
+import { useColonyClient, useHasDomainPermission } from "../../contexts/ColonyContext";
+
 import { REWARDS_FUNDING_POT_ID } from "../../constants";
+
+import { Token } from "../../typings";
 
 const UnderlinedTableRow = styled(TableRow)`
   border-bottom-width: 3px;
@@ -57,11 +62,14 @@ const NewPayoutRow = () => {
 };
 
 const PayoutList = ({ tokens }: { tokens: Token[] }) => {
+  const safeInfo = useSafeInfo();
+  const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, 1, ColonyRole.Root);
+
   const tokenList = useMemo(() => tokens.map(token => <TokenRow token={token} />), [tokens]);
 
   return (
     <Table>
-      <NewPayoutRow />
+      {hasRootPermission && <NewPayoutRow />}
       {tokenList}
     </Table>
   );

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -3,10 +3,11 @@ import { formatUnits } from "ethers/utils";
 
 import { TableRow, TableCell } from "@material-ui/core";
 import { Text, Icon } from "@gnosis.pm/safe-react-components";
-import styled from "styled-components";
 
 import { ColonyRole } from "@colony/colony-js";
 import Table from "../common/StyledTable";
+import UnderlinedTableRow from "../common/UnderLinedTableRow";
+
 import PayoutModal from "../Modals/PayoutModal";
 
 import { useSafeInfo } from "../../contexts/SafeContext";
@@ -15,11 +16,6 @@ import { useColonyClient, useHasDomainPermission } from "../../contexts/ColonyCo
 import { REWARDS_FUNDING_POT_ID } from "../../constants";
 
 import { Token } from "../../typings";
-
-const UnderlinedTableRow = styled(TableRow)`
-  border-bottom-width: 3px;
-  border-bottom-style: solid;
-`;
 
 const TokenRow = ({ token }: { token: Token }) => {
   const colonyClient = useColonyClient();

--- a/src/components/PayoutList/index.tsx
+++ b/src/components/PayoutList/index.tsx
@@ -1,11 +1,20 @@
 import React, { useMemo, useState, useEffect } from "react";
-import { TableRow, TableCell } from "@material-ui/core";
 import { formatUnits } from "ethers/utils";
+
+import { TableRow, TableCell } from "@material-ui/core";
+import { Text, Icon } from "@gnosis.pm/safe-react-components";
+import styled from "styled-components";
+
 import Table from "../common/StyledTable";
 import PayoutModal from "../Modals/PayoutModal";
 import { Token } from "../../typings";
 import { useColonyClient } from "../../contexts/ColonyContext";
 import { REWARDS_FUNDING_POT_ID } from "../../constants";
+
+const UnderlinedTableRow = styled(TableRow)`
+  border-bottom-width: 3px;
+  border-bottom-style: solid;
+`;
 
 const TokenRow = ({ token }: { token: Token }) => {
   const colonyClient = useColonyClient();
@@ -31,10 +40,31 @@ const TokenRow = ({ token }: { token: Token }) => {
   );
 };
 
+const NewPayoutRow = () => {
+  // const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <>
+      <UnderlinedTableRow onClick={() => console.log("Opening New Payout modal")}>
+        <TableCell>
+          <Text size="lg">New Payout</Text>
+        </TableCell>
+        <TableCell align="right">
+          <Icon type="add" size="md" />
+        </TableCell>
+      </UnderlinedTableRow>
+    </>
+  );
+};
+
 const PayoutList = ({ tokens }: { tokens: Token[] }) => {
   const tokenList = useMemo(() => tokens.map(token => <TokenRow token={token} />), [tokens]);
 
-  return <Table>{tokenList}</Table>;
+  return (
+    <Table>
+      <NewPayoutRow />
+      {tokenList}
+    </Table>
+  );
 };
 
 export default PayoutList;

--- a/src/components/PermissionsList/index.tsx
+++ b/src/components/PermissionsList/index.tsx
@@ -1,22 +1,16 @@
 import React, { useMemo, useState, useCallback } from "react";
 import { TableRow, TableCell, Tooltip } from "@material-ui/core";
 
-import styled from "styled-components";
-
 import { ColonyRoles, DomainRoles, ColonyRole } from "@colony/colony-js";
 
 import { Text, Icon } from "@gnosis.pm/safe-react-components";
+import UnderlinedTableRow from "../common/UnderLinedTableRow";
 import Table from "../common/StyledTable";
 import PermissionsModal from "../Modals/PermissionsModal";
 import PermissionIcons from "./PermissionIcons";
 import Address from "../common/Address";
 import { useColonyRoles, useHasDomainPermission } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
-
-const UnderlinedTableRow = styled(TableRow)`
-  border-bottom-width: 3px;
-  border-bottom-style: solid;
-`;
 
 const AddressRow = ({
   address,

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -1,9 +1,12 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { TableRow, TableCell } from "@material-ui/core";
+
 import { ColonyRole, ColonyClient } from "@colony/colony-js";
 import { formatUnits, BigNumber } from "ethers/utils";
-import Table from "../common/StyledTable";
+import { Text, Icon } from "@gnosis.pm/safe-react-components";
 
+import Table from "../common/StyledTable";
+import UnderlinedTableRow from "../common/UnderLinedTableRow";
 import TokenModal from "../Modals/TokenModal";
 import { useHasDomainPermission, useColonyClient, useColonyDomains } from "../../contexts/ColonyContext";
 import { useSafeInfo } from "../../contexts/SafeContext";
@@ -82,6 +85,22 @@ const TokenRow = ({
   );
 };
 
+const MintTokensRow = () => {
+  // const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <>
+      <UnderlinedTableRow onClick={() => console.log("Opening Mint Tokens modal")}>
+        <TableCell>
+          <Text size="lg">Mint Tokens</Text>
+        </TableCell>
+        <TableCell align="right">
+          <Icon type="add" size="md" />
+        </TableCell>
+      </UnderlinedTableRow>
+    </>
+  );
+};
+
 const TokenList = ({ tokens, currentDomainId }: { tokens: Token[]; currentDomainId: number }) => {
   const safeInfo = useSafeInfo();
   const hasRootPermission = useHasDomainPermission(safeInfo?.safeAddress, currentDomainId, ColonyRole.Root);
@@ -106,7 +125,12 @@ const TokenList = ({ tokens, currentDomainId }: { tokens: Token[]; currentDomain
     [tokens, currentDomainId, hasRootPermission, hasAdministrationPermission, hasFundingPermission],
   );
 
-  return <Table>{tokenList}</Table>;
+  return (
+    <Table>
+      {hasRootPermission && <MintTokensRow />}
+      {tokenList}
+    </Table>
+  );
 };
 
 export default TokenList;

--- a/src/components/TokenList/index.tsx
+++ b/src/components/TokenList/index.tsx
@@ -44,13 +44,11 @@ const getDomainTokenBalance = (
 const TokenRow = ({
   token,
   domainId,
-  hasRootRole,
   hasAdministrationRole,
   hasFundingRole,
 }: {
   token: Token;
   domainId: number;
-  hasRootRole: boolean;
   hasAdministrationRole: boolean;
   hasFundingRole: boolean;
 }) => {
@@ -73,7 +71,6 @@ const TokenRow = ({
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         token={token}
-        hasRootRole={hasRootRole}
         hasAdministrationRole={hasAdministrationRole}
         hasFundingRole={hasFundingRole}
       />
@@ -117,12 +114,11 @@ const TokenList = ({ tokens, currentDomainId }: { tokens: Token[]; currentDomain
         <TokenRow
           token={token}
           domainId={currentDomainId}
-          hasRootRole={hasRootPermission}
           hasAdministrationRole={hasAdministrationPermission}
           hasFundingRole={hasFundingPermission}
         />
       )),
-    [tokens, currentDomainId, hasRootPermission, hasAdministrationPermission, hasFundingPermission],
+    [tokens, currentDomainId, hasAdministrationPermission, hasFundingPermission],
   );
 
   return (

--- a/src/components/common/UnderLinedTableRow.tsx
+++ b/src/components/common/UnderLinedTableRow.tsx
@@ -1,0 +1,9 @@
+import { TableRow } from "@material-ui/core";
+import styled from "styled-components";
+
+const UnderlinedTableRow = styled(TableRow)`
+  border-bottom-width: 3px;
+  border-bottom-style: solid;
+`;
+
+export default UnderlinedTableRow;

--- a/src/contexts/ColonyContext.tsx
+++ b/src/contexts/ColonyContext.tsx
@@ -223,4 +223,19 @@ export const useTokensInfo = () => {
   return tokensInfo;
 };
 
+export const useRewardInverse = (): BigNumber => {
+  const colonyClient = useColonyClient();
+  const [rewardInverse, setRewardInverse] = useState<BigNumber>(
+    new BigNumber("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+  );
+
+  useEffect(() => {
+    if (colonyClient) {
+      colonyClient.getRewardInverse().then((rewards: BigNumber) => setRewardInverse(rewards));
+    }
+  }, [colonyClient]);
+
+  return rewardInverse;
+};
+
 export default ColonyProvider;


### PR DESCRIPTION
This adds a (stubbed) button to the Rewards tab to start a new payout round. This lead to the situation where the "permissions" and "rewards" tabs have this extra row but the "tokens"does not.

I've taken the opportunity to create a similar row in the tokens tab to allow minting of native tokens. This also offloads this reponsibility from the `TokensModal` allowing it to be identical across native and non-native tokens.